### PR TITLE
Should fix if can't find contact

### DIFF
--- a/pebblesmstweak/main.xm
+++ b/pebblesmstweak/main.xm
@@ -1318,7 +1318,11 @@ static void saveRecentRecipient(NSString *name, NSString *phone) {
     }
 
     // NSLog(@"PEBBLESMS: finalContact == NULL %d", (finalContact == NULL));
-    return finalContact;
+    if (highestCount >= 6) { // just double check that there was actually a find
+        return finalContact;
+    }
+
+    return NULL;
 }
 
 %new
@@ -1873,7 +1877,15 @@ static void saveRecentRecipient(NSString *name, NSString *phone) {
         PBPhoneNumber *pbPhone = [[%c(PBPhoneNumber) alloc] initWithStringValue:phone];
         PBContact *contact = [[%c(PBAddressBook) addressBook] contactWithPhoneNumber:pbPhone];
 
-        if (contact != NULL) {
+        PBContact *finalContact;
+        if (contact == NULL) {
+            NSString *prefixedPhone = [%c(PBContact) phoneWithPrefix:phone];
+            finalContact = [[%c(PBAddressBook) addressBook] contactWithPrefixedPhoneNumber:prefixedPhone];
+        } else {
+            finalContact = contact;
+        }
+
+        if (finalContact != NULL) {
             PBTimelineAttributeContentLocalizedString *localString = [[%c(PBTimelineAttributeContentLocalizedString) alloc] initWithLocalizationKey:@"Sending..."];
             PBTimelineAttribute *attr = [%c(PBTimelineAttribute) attributeWithType:@"subtitle" content:localString];
             [(PBTimelineActionsWatchService *)[self delegate] sendTextAppActionHandler:self didSendResponse:0 withAttributes:@[attr] forItemIdentifier:arg2];


### PR DESCRIPTION
If it can't find a contact based on an exact match (most likely due to spaces or country code issues), it will search. In addition, I added a check to make sure that a search by phone number returns something that matches reasonably well (and reasonably well should be good enough given that we are searching our contacts and it is very unlikely that anybody is searching for a number that is not in their contacts list). 
